### PR TITLE
メッセージ送信機能のルーティング設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,7 @@ Rails.application.routes.draw do
   devise_for :users
   root "groups#index"
   resources :users, only: [:edit, :update]
-  resources :groups, only: [:index, :new, :create, :edit, :update]
+  resources :groups, only: [:new, :create, :edit, :update] do
+    resources :messages, only: [:index, :create]
+  end
 end


### PR DESCRIPTION
#what
メッセージ送信機能のルーティングを記述。
routes.rb


#why
メッセージ送信機能を実装するに当たってルーティングの設定は必須のため